### PR TITLE
Added more link and include directory options for cmake.

### DIFF
--- a/fleece/CMakeLists.txt
+++ b/fleece/CMakeLists.txt
@@ -2,12 +2,30 @@ cmake_minimum_required (VERSION 2.6.4)
 
 project (Fleece)
 
-set(CMAKE_INSTALL_PREFIX "/usr" CACHE PATH "Default installation path")
-set(CMAKE_BUILD_TYPE "Release" CACHE STRING "Build type")
+IF(CMAKE_INSTALL_PREFIX_INITIALIZED_TO_DEFAULT)
+	set(CMAKE_INSTALL_PREFIX "/usr" CACHE PATH "Default installation path" FORCE)
+    set(CMAKE_BUILD_TYPE "Release" CACHE STRING "Build type" FORCE)
+
+
+    set(DYNINST_LIBDIR "/usr/lib" CACHE STRING "Library directory for Dyninst" FORCE)
+    set(DYNINST_INCLUDEDIR "/usr/include" CACHE STRING "Include directory for Dyninst" FORCE)
+    
+    set(XED_LIBDIR "/usr/lib" CACHE STRING "Library directory for XED" FORCE)
+    set(XED_INCLUDEDIR "/usr/include" CACHE STRING "Include directory for XED" FORCE)
+
+    set(GNU_LIBDIR "/usr/lib" CACHE STRING "Library directory for binutils" FORCE)
+    set(GNU_INCLUDEDIR "/usr/include" CACHE STRING "Include directory for binutils" FORCE)
+
+    set(LLVM_LIBDIR "/usr/lib" CACHE STRING "Library directory for LLVM" FORCE)
+    set(LLVM_INCLUDEDIR "/usr/include" CACHE STRING "Include directory for LLVM" FORCE)
+
+ENDIF(CMAKE_INSTALL_PREFIX_INITIALIZED_TO_DEFAULT)
 
 option(BUILD_SHARED "Build and link shared libraries?" ON)
 option(BUILD_STATIC "Build and link static libraries?" OFF)
 
+set (DEPS_LIBDIR ${DYNINST_LIBDIR} ${XED_LIBDIR} ${GNU_LIBDIR} ${LLVM_LIBDIR})
+set (DEPS_INCLUDEDIR ${DYNINST_INCLUDEDIR} ${XED_INCLUDEDIR} ${GNU_INCLUDEDIR} ${LLVM_INCLUDEDIR})
 
 # Which custom libraries should be linked against fleece?
 set (FLEECE_LIBRARIES fleeceutil fleecedecoders fleecereporting)
@@ -20,8 +38,8 @@ set (CMAKE_C_FLAGS "")
 set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} -ggdb -gdwarf-2 -Wall")
 set(CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE} -Wall")
 
-
-include_directories(${PROJECT_BINARY_DIR}/h)
+include_directories(${PROJECT_BINARY_DIR}/h ${DEPS_INCLUDEDIR})
+link_directories(${DEPS_LIBDIR})
 
 add_subdirectory(decoders)
 add_subdirectory(reporting)


### PR DESCRIPTION
This should let you specify include/library directories for all of the dependent packages.

@nathanhjay this is a cleaner fix for your issue
