### PR TITLE
Added capstone disassembler.

### DIFF
--- a/fleece/CMakeLists.txt
+++ b/fleece/CMakeLists.txt
@@ -18,18 +18,20 @@ IF(CMAKE_INSTALL_PREFIX_INITIALIZED_TO_DEFAULT)
 
     set(LLVM_LIBDIR "/usr/lib" CACHE STRING "Library directory for LLVM" FORCE)
     set(LLVM_INCLUDEDIR "/usr/include" CACHE STRING "Include directory for LLVM" FORCE)
+    set(CAPSTONE_LIBDIR "/usr/lib" CACHE STRING "Library directory for Capstone" FORCE)
+    set(CAPSTONE_INCLUDEDIR "/usr/include" CACHE STRING "Include directory for Capstone" FORCE)
 
 ENDIF(CMAKE_INSTALL_PREFIX_INITIALIZED_TO_DEFAULT)
 
 option(BUILD_SHARED "Build and link shared libraries?" ON)
 option(BUILD_STATIC "Build and link static libraries?" OFF)
 
-set (DEPS_LIBDIR ${DYNINST_LIBDIR} ${XED_LIBDIR} ${GNU_LIBDIR} ${LLVM_LIBDIR})
-set (DEPS_INCLUDEDIR ${DYNINST_INCLUDEDIR} ${XED_INCLUDEDIR} ${GNU_INCLUDEDIR} ${LLVM_INCLUDEDIR})
+set (DEPS_LIBDIR ${DYNINST_LIBDIR} ${XED_LIBDIR} ${GNU_LIBDIR} ${LLVM_LIBDIR} ${CAPSTONE_LIBDIR})
+set (DEPS_INCLUDEDIR ${DYNINST_INCLUDEDIR} ${XED_INCLUDEDIR} ${GNU_INCLUDEDIR} ${LLVM_INCLUDEDIR} ${CAPSTONE_INCLUDEDIR})
 
 # Which custom libraries should be linked against fleece?
 set (FLEECE_LIBRARIES fleeceutil fleecedecoders fleecereporting)
-set (OTHER_LIBRARIES z instructionAPI xed LLVM opcodes rt bfd iberty dl)
+set (OTHER_LIBRARIES z instructionAPI xed LLVM opcodes capstone rt bfd iberty dl)
 set (ALL_LIBRARIES ${FLEECE_LIBRARIES} ${OTHER_LIBRARIES})
 
 set (CMAKE_CXX_FLAGS "-std=c++0x")

--- a/fleece/LICENSE_CAPSTONE
+++ b/fleece/LICENSE_CAPSTONE
@@ -1,0 +1,31 @@
+This is the software license for Capstone disassembly framework.
+Capstone has been designed & implemented by Nguyen Anh Quynh <aquynh@gmail.com>
+
+See http://www.capstone-engine.org for further information.
+
+Copyright (c) 2013, COSEINC.
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+* Redistributions of source code must retain the above copyright notice,
+  this list of conditions and the following disclaimer.
+* Redistributions in binary form must reproduce the above copyright notice,
+  this list of conditions and the following disclaimer in the documentation
+  and/or other materials provided with the distribution.
+* Neither the name of the developer(s) nor the names of its
+  contributors may be used to endorse or promote products derived from this
+  software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+POSSIBILITY OF SUCH DAMAGE.

--- a/fleece/decoders/CMakeLists.txt
+++ b/fleece/decoders/CMakeLists.txt
@@ -1,5 +1,6 @@
 # Set the sources that should be compiled into the library
-set (FLEECE_DECODERS_SOURCE aarch64_common.C Decoder.C dyninst_aarch64.C dyninst_x86_64.C gnu_aarch64.C gnu_x86_64.C llvm_aarch64.C llvm_common.C llvm_x86_64.C Normalization.C null_decoders.C xed_x86_64.C)
+set (FLEECE_DECODERS_SOURCE aarch64_common.C Decoder.C dyninst_aarch64.C dyninst_x86_64.C gnu_aarch64.C gnu_x86_64.C
+llvm_aarch64.C llvm_common.C llvm_x86_64.C Normalization.C null_decoders.C xed_x86_64.C capstone_aarch64.C capstone_x86_64.C)
 
 # When binaries link against this library, which headers should be included?
 include_directories ("${PROJECT_SOURCE_DIR}/h")

--- a/fleece/decoders/Decoder.C
+++ b/fleece/decoders/Decoder.C
@@ -29,6 +29,8 @@ Decoder* dec_gnu_x86_64;
 Decoder* dec_gnu_aarch64;
 Decoder* dec_llvm_x86_64;
 Decoder* dec_llvm_aarch64;
+Decoder* dec_capstone_x86_64;
+Decoder* dec_capstone_aarch64;
 Decoder* dec_null_x86_64;
 Decoder* dec_null_aarch64;
 
@@ -71,6 +73,10 @@ void Decoder::initAllDecoders()
             &llvm_x86_64_norm, "llvm", "x86_64");
     dec_llvm_aarch64 = new Decoder(&llvm_aarch64_decode, &LLVMInit, 
             &llvm_aarch64_norm, "llvm", "aarch64");
+    dec_capstone_x86_64 = new Decoder(&capstone_x86_64_decode, NULL, 
+            &capstone_x86_64_norm, "capstone", "x86_64");
+    dec_capstone_aarch64 = new Decoder(&capstone_aarch64_decode, NULL, 
+            &capstone_aarch64_norm, "capstone", "aarch64");
     dec_null_x86_64 = new Decoder(&null_x86_64_decode, NULL, 
             &null_x86_64_norm, "null", "x86_64");
     dec_null_aarch64 = new Decoder(&null_aarch64_decode, NULL, 
@@ -86,6 +92,8 @@ void Decoder::destroyAllDecoders()
     delete dec_gnu_aarch64;
     delete dec_llvm_x86_64;
     delete dec_llvm_aarch64;
+    delete dec_capstone_x86_64;
+    delete dec_capstone_aarch64;
     delete dec_null_x86_64;
     delete dec_null_aarch64;
 }
@@ -99,6 +107,8 @@ std::vector<Decoder> Decoder::getAllDecoders() {
    dec.push_back(*dec_dyninst_x86_64);
    dec.push_back(*dec_dyninst_aarch64);
    dec.push_back(*dec_xed_x86_64);
+   dec.push_back(*dec_capstone_x86_64);
+   dec.push_back(*dec_capstone_aarch64);
    dec.push_back(*dec_null_aarch64);
    dec.push_back(*dec_null_x86_64);
    return dec;

--- a/fleece/decoders/capstone_aarch64.C
+++ b/fleece/decoders/capstone_aarch64.C
@@ -1,0 +1,49 @@
+
+/*
+ * See fleece/COPYRIGHT for copyright information.
+ *
+ * This file is a part of Fleece.
+ *
+ * Fleece is free software; you can redistribute it and/or modify it under the
+ * terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 3.0 of the License, or (at your option)
+ * any later version.
+ *  
+ * This software is distributed in the hope that it will be useful, but WITHOUT 
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ * 
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this software; if not, see www.gnu.org/licenses
+*/
+
+#include "Normalization.h"
+#include "capstone/capstone.h"
+
+int capstone_aarch64_decode(char* inst, int nBytes, char* buf, int bufLen) {
+
+   csh handle;
+   cs_insn *insn;
+   size_t count;
+
+   if (cs_open(CS_ARCH_ARM64, CS_MODE_ARM, &handle) != CS_ERR_OK) {
+      return -1;
+   }
+
+   int nInsns = cs_disasm(handle, (uint8_t*)inst, nBytes, 0x1000, 0, &insn);
+   
+   if (nInsns < 1) {
+      return -1;
+   }
+   
+   snprintf(buf, bufLen, "%s %s", insn[0].mnemonic, insn[0].op_str);
+   cs_free(insn, nInsns);
+   cs_close(&handle);
+   return 0;
+
+}
+
+void capstone_aarch64_norm(char* buf, int bufLen) {
+
+}

--- a/fleece/decoders/capstone_x86_64.C
+++ b/fleece/decoders/capstone_x86_64.C
@@ -1,0 +1,49 @@
+
+/*
+ * See fleece/COPYRIGHT for copyright information.
+ *
+ * This file is a part of Fleece.
+ *
+ * Fleece is free software; you can redistribute it and/or modify it under the
+ * terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 3.0 of the License, or (at your option)
+ * any later version.
+ *  
+ * This software is distributed in the hope that it will be useful, but WITHOUT 
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ * 
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this software; if not, see www.gnu.org/licenses
+*/
+
+#include "Normalization.h"
+#include "capstone/capstone.h"
+
+int capstone_x86_64_decode(char* inst, int nBytes, char* buf, int bufLen) {
+
+   csh handle;
+   cs_insn *insn;
+   size_t count;
+   if (cs_open(CS_ARCH_X86, CS_MODE_64, &handle) != CS_ERR_OK) {
+      return -1;
+   }
+   cs_option(handle, CS_OPT_SYNTAX, CS_OPT_SYNTAX_ATT);
+
+   int nInsns = cs_disasm(handle, (uint8_t*)inst, nBytes, 0x1000, 0, &insn);
+   
+   if (nInsns < 1) {
+      return -1;
+   }
+   
+   snprintf(buf, bufLen, "%s %s", insn[0].mnemonic, insn[0].op_str);
+   cs_free(insn, nInsns);
+   cs_close(&handle);
+   return 0;
+
+}
+
+void capstone_x86_64_norm(char* buf, int bufLen) {
+
+}

--- a/fleece/h/Decoder.h
+++ b/fleece/h/Decoder.h
@@ -85,6 +85,12 @@ extern void llvm_x86_64_norm      (char*, int);
 extern int  llvm_aarch64_decode   (char*, int, char*, int);
 extern void llvm_aarch64_norm     (char*, int);
 
+extern int  capstone_x86_64_decode    (char*, int, char*, int);
+extern void capstone_x86_64_norm      (char*, int);
+
+extern int  capstone_aarch64_decode   (char*, int, char*, int);
+extern void capstone_aarch64_norm     (char*, int);
+
 extern int  null_aarch64_decode   (char*, int, char*, int);
 extern void null_aarch64_norm     (char*, int);
 
@@ -101,6 +107,9 @@ extern Decoder* dec_gnu_aarch64;
 
 extern Decoder* dec_llvm_x86_64;
 extern Decoder* dec_llvm_aarch64;
+
+extern Decoder* dec_capstone_x86_64;
+extern Decoder* dec_capstone_aarch64;
 
 extern Decoder* dec_null_x86_64;
 extern Decoder* dec_null_aarch64;


### PR DESCRIPTION
This branch has decoder objects for Capstone for ARM and x86 with empty normalization methods. It includes Capstone in the cmake system, and includes its license in the root project directory.
