### PR TITLE
Fixes/llvm crash on decode

### DIFF
--- a/fleece/decoders/Decoder.C
+++ b/fleece/decoders/Decoder.C
@@ -39,20 +39,21 @@ Decoder::Decoder(
         const char* name,
         const char* arch) {
 
-   func = decodeFunc;
-   normFunc = normFunction;
+    func = decodeFunc;
+    normFunc = normFunction;
    
-   // Execute any initialization required for this decoder.
-   if (initFunc != NULL) {
-      assert((*initFunc)() != -1);
-   }
+    // Execute any initialization required for this decoder.
+    if (initFunc != NULL) {
+        int initResult = (*initFunc)();
+        assert(initResult != -1);
+    }
    
-   this->arch = arch;
-   this->name = name;
+    this->arch = arch;
+    this->name = name;
 
-   totalNormTime = 0;
-   totalDecodeTime = 0;
-   totalDecodedInsns = 0;
+    totalNormTime = 0;
+    totalDecodeTime = 0;
+    totalDecodedInsns = 0;
 }
 
 void Decoder::initAllDecoders()

--- a/fleece/decoders/llvm_aarch64.C
+++ b/fleece/decoders/llvm_aarch64.C
@@ -234,17 +234,17 @@ int llvm_aarch64_decode(char* inst, int nBytes, char* buf, int bufLen) {
 
     static LLVMDisasmContextRef disasm = LLVMCreateDisasm(
         "aarch64-linux-gnu", 
-         nullptr, 
-         0, 
-         nullptr, 
-         LLVMCallback);
+        nullptr, 
+        0, 
+        nullptr, 
+        LLVMCallback);
 
     size_t bytesUsed = LLVMDisasmInstruction(
-            disasm, 
-            (uint8_t*)inst, 
-            nBytes, 0, 
-            buf, 
-            (size_t)bufLen);
+        disasm, 
+        (uint8_t*)inst, 
+        nBytes, 0, 
+        buf, 
+        (size_t)bufLen);
 
 
     if (!bytesUsed) {

--- a/fleece/decoders/llvm_aarch64.C
+++ b/fleece/decoders/llvm_aarch64.C
@@ -232,15 +232,26 @@ static const char* LLVMCallback(void* info, uint64_t refVal, uint64_t* refType, 
 
 int llvm_aarch64_decode(char* inst, int nBytes, char* buf, int bufLen) {
 
-   static LLVMDisasmContextRef disasm = LLVMCreateDisasm("aarch64-linux-gnu", nullptr, 0, nullptr, LLVMCallback);
+    static LLVMDisasmContextRef disasm = LLVMCreateDisasm(
+        "aarch64-linux-gnu", 
+         nullptr, 
+         0, 
+         nullptr, 
+         LLVMCallback);
 
-   size_t bytesUsed = LLVMDisasmInstruction(disasm, (uint8_t*)inst, nBytes, 0, buf, (size_t)bufLen);
+    size_t bytesUsed = LLVMDisasmInstruction(
+            disasm, 
+            (uint8_t*)inst, 
+            nBytes, 0, 
+            buf, 
+            (size_t)bufLen);
 
-   if (!bytesUsed) {
-      strncpy(buf, "llvm_decoding_error", bufLen);
-   }
 
-   return !bytesUsed;
+    if (!bytesUsed) {
+        strncpy(buf, "llvm_decoding_error", bufLen);
+    }
+
+    return !bytesUsed;
 }
 
 void llvm_aarch64_norm(char* buf, int bufLen) {

--- a/fleece/decoders/llvm_common.C
+++ b/fleece/decoders/llvm_common.C
@@ -19,6 +19,7 @@
 */
 
 #include "llvm_common.h"
+#include <iostream>
 
 #if 0
 static const char* LLVMCallback(void* info, uint64_t refVal, uint64_t* refType, uint64_t refPC, const char** refName) {
@@ -30,12 +31,12 @@ static const char* LLVMCallback(void* info, uint64_t refVal, uint64_t* refType, 
 #endif
 
 int LLVMInit() {
-   
-   llvm::InitializeAllTargetInfos();
-   llvm::InitializeAllTargetMCs();
-   llvm::InitializeAllDisassemblers();
 
-   return 0;
+    llvm::InitializeAllTargetInfos();
+    llvm::InitializeAllTargetMCs();
+    llvm::InitializeAllDisassemblers();
+
+    return 0;
 
 }
 

--- a/fleece/decoders/llvm_x86_64.C
+++ b/fleece/decoders/llvm_x86_64.C
@@ -20,6 +20,7 @@
 
 #include "Normalization.h"
 #include "Mystring.h"
+#include <iostream>
 #include <iomanip>
 #include "llvm_common.h"
 
@@ -32,11 +33,22 @@ static const char* LLVMCallback(void* info, uint64_t refVal, uint64_t* refType, 
 
 int llvm_x86_64_decode(char* inst, int nBytes, char* buf, int bufLen) {
 
-   static LLVMDisasmContextRef disasm = LLVMCreateDisasm("x86_64-linux-gnu", nullptr, 0, nullptr, LLVMCallback);
+    static LLVMDisasmContextRef disasm = LLVMCreateDisasm(
+        "x86_64-linux-gnu", 
+        nullptr, 
+        0, 
+        nullptr, 
+        LLVMCallback);
 
-   size_t bytesUsed = LLVMDisasmInstruction(disasm, (uint8_t*)inst, nBytes, 0, buf, (size_t)bufLen);
+    size_t bytesUsed = LLVMDisasmInstruction(
+        disasm, 
+        (uint8_t*)inst, 
+        nBytes, 
+        0, 
+        buf, 
+        (size_t)bufLen);
 
-   return !bytesUsed;
+    return !bytesUsed;
 }
 
 void llvm_x86_64_norm(char* buf, int bufLen) {


### PR DESCRIPTION
Fixed issue where decoder initializer functions were called from an assert statement, and so removed in release mode.
