### PR TITLE
Only build shared objects for fleece internal libraries

### DIFF
--- a/fleece/CMakeLists.txt
+++ b/fleece/CMakeLists.txt
@@ -14,9 +14,6 @@ IF(CMAKE_INSTALL_PREFIX_INITIALIZED_TO_DEFAULT)
 
 ENDIF(CMAKE_INSTALL_PREFIX_INITIALIZED_TO_DEFAULT)
 
-option(BUILD_SHARED "Build and link shared libraries?" ON)
-option(BUILD_STATIC "Build and link static libraries?" OFF)
-
 set (DYNINST_LIBDIR "${DYNINST_DIR}/lib")
 set (DYNINST_INCLUDEDIR "${DYNINST_DIR}/include")
 

--- a/fleece/decoders/CMakeLists.txt
+++ b/fleece/decoders/CMakeLists.txt
@@ -1,16 +1,9 @@
 # Set the sources that should be compiled into the library
 set (FLEECE_DECODERS_SOURCE aarch64_common.C Decoder.C dyninst_aarch64.C dyninst_x86_64.C gnu_aarch64.C gnu_x86_64.C
-llvm_aarch64.C llvm_common.C llvm_x86_64.C Normalization.C null_decoders.C xed_x86_64.C capstone_aarch64.C capstone_x86_64.C)
+    llvm_aarch64.C llvm_common.C llvm_x86_64.C Normalization.C null_decoders.C xed_x86_64.C capstone_aarch64.C capstone_x86_64.C)
 
 # When binaries link against this library, which headers should be included?
 include_directories ("${PROJECT_SOURCE_DIR}/h")
 
-if(BUILD_SHARED)
-    # Build these sources as libfleecedecoders (.so on Linux or .dll on Windows)
-    add_library(fleecedecoders SHARED ${FLEECE_DECODERS_SOURCE})
-endif(BUILD_SHARED)
-
-if(BUILD_STATIC)
-    # Build these sources as libfleecedecoders (.so on Linux or .dll on Windows)
-    add_library(fleecedecoders STATIC ${FLEECE_DECODERS_SOURCE})
-endif(BUILD_STATIC)
+# Build these sources as libfleecedecoders (.so on Linux or .dll on Windows)
+add_library(fleecedecoders SHARED ${FLEECE_DECODERS_SOURCE})

--- a/fleece/reporting/CMakeLists.txt
+++ b/fleece/reporting/CMakeLists.txt
@@ -4,13 +4,6 @@ set (FLEECE_REPORTING_SOURCE ReportingContext.C)
 # When binaries link against this library, which headers should be included?
 include_directories (${PROJECT_SOURCE_DIR}/h})
 
-if(BUILD_SHARED)
-    # Build these sources as libfleecereporting (.so on Linux or .dll on Windows)
-    add_library(fleecereporting SHARED ${FLEECE_REPORTING_SOURCE})
-endif(BUILD_SHARED)
-
-if(BUILD_STATIC)
-    # Build these sources as libfleecereporting (.so on Linux or .dll on Windows)
-    add_library(fleecereporting STATIC ${FLEECE_REPORTING_SOURCE})
-endif(BUILD_STATIC)
+# Build these sources as libfleecereporting (.so on Linux or .dll on Windows)
+add_library(fleecereporting SHARED ${FLEECE_REPORTING_SOURCE})
 

--- a/fleece/util/CMakeLists.txt
+++ b/fleece/util/CMakeLists.txt
@@ -4,13 +4,6 @@ set (FLEECE_UTIL_SOURCE Alias.C Architecture.C Bitfield.C BitTypeMap.C BitTypes.
 # When binaries link against this library, which headers should be included?
 include_directories (${PROJECT_SOURCE_DIR}/h})
 
-if(BUILD_SHARED)
-    # Build these sources as libfleeceutil (.so on Linux or .dll on Windows)
-    add_library(fleeceutil SHARED ${FLEECE_UTIL_SOURCE})
-endif(BUILD_SHARED)
-
-if(BUILD_STATIC)
-    # Build these sources as libfleeceutil (.so on Linux or .dll on Windows)
-    add_library(fleeceutil STATIC ${FLEECE_UTIL_SOURCE})
-endif(BUILD_STATIC)
+# Build these sources as libfleeceutil (.so on Linux or .dll on Windows)
+add_library(fleeceutil SHARED ${FLEECE_UTIL_SOURCE})
 


### PR DESCRIPTION
The static libraries don't really need to be built, static should always suffice. This has caused compiling issues in the past when the developer disables or enables both shared and static libraries.
